### PR TITLE
Feature/5 remove incomplete items from previous notes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ interface NestedDailyTodosSettings {
     lookBackExistingNotesInsteadOfDays: boolean;
     groupBySection: boolean;
     removeEmptyTodos: boolean;
+    removeIncompleteTodosFromPreviousNotes: boolean;
     supportedTodoChars: Set<string>;
     completeTodoChars: Set<string>;
 }
@@ -24,6 +25,7 @@ export const DEFAULT_SETTINGS: NestedDailyTodosSettings = {
     lookBackExistingNotesInsteadOfDays: false,
     groupBySection: true,
     removeEmptyTodos: true,
+    removeIncompleteTodosFromPreviousNotes: false,
     supportedTodoChars: new Set(['x', 'X', '/', '-']),
     completeTodoChars: new Set(['x', 'X', '-'])
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
     insertIncompleteTodos,
     parseTextForTodos,
     removeEmptyTodos,
+    removeIncompleteTodos,
     TodoNode
 } from './todo';
 import {NestedDailyTodosSettingTab} from './settings';
@@ -127,6 +128,7 @@ export async function addIncompleteTodosToTodaysNote(plugin: NestedDailyTodos) {
         notesToProcess = [...prevNotes.map(key => allDailyNotes[key])];
     }
     notesToProcess = notesToProcess.reverse();
+    const previousNotes = notesToProcess.slice(0, -1);
 
     console.debug(`Running with: supportedTodoChars: "${Array.from(settings.supportedTodoChars).join("")}", completeTodoChars: "${Array.from(settings.completeTodoChars).join("")}"`)
     console.info(`Checking notes: ${notesToProcess.map(note => note.name).join(', ')}`);
@@ -176,6 +178,24 @@ export async function addIncompleteTodosToTodaysNote(plugin: NestedDailyTodos) {
                 todayNote,
                 removeEmptyTodos.bind(null)
             )
+    }
+
+    if (settings.removeIncompleteTodosFromPreviousNotes && numMissingTodos > 0) {
+        // Remove the inserted todos from the previous notes
+        // Rather than removing them during the original parsing, they are only removed after today's note has been
+        // updated to reduce chances of data loss
+        console.info("Removing incomplete todos from previous notes that were carried forward");
+        for (const previousNote of previousNotes) {
+            const previousNoteText: string = await this.app.vault.read(previousNote);
+            const updatedNoteText = removeIncompleteTodos(
+                previousNoteText,
+                missingIncompleteTodos,
+                settings.groupBySection,
+                settings.supportedTodoChars,
+                settings.completeTodoChars
+            );
+            await this.app.vault.modify(previousNote, updatedNoteText);
+        }
     }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -59,6 +59,31 @@ export class NestedDailyTodosSettingTab extends PluginSettingTab {
                 })
             )
         new Setting(containerEl)
+            .setName('Remove incomplete todos from previous notes')
+            .setDesc((() => {
+                const fragment = document.createDocumentFragment();
+                const description = document.createElement("div");
+                description.innerHTML = `
+                ⚠ This setting is destructive, data loss can occur. Please use with care and ensure your vault is 
+                backed up.<br>
+                Please be particularly aware that this plugin does not enforce equality of a Todo's children. If the 
+                same top-level Todo has different children in a newer note, enabling this option will remove the older 
+                todo and its children, permanently losing the information about what the previous children 
+                were. ⚠<br><br>
+                When enabled, todos that are added to today's Daily Note will be removed from the parsed previous notes.
+                When left disabled, previous notes are left unchanged and the most recent version of incomplete todos are copied to today's Daily Note.
+            `;
+                fragment.appendChild(description);
+                return fragment;
+            })())
+            .addToggle((toggle) => toggle
+                .setValue(this.plugin.settings.removeIncompleteTodosFromPreviousNotes)
+                .onChange(async (value) => {
+                    this.plugin.settings.removeIncompleteTodosFromPreviousNotes = value
+                    await this.plugin.saveSettings()
+                })
+            )
+        new Setting(containerEl)
             .setName('Supported Todo characters')
             .setDesc('Todo items with these values will be considered todos and carried forward if incomplete. If ' +
                 'you use a theme or plugin that makes use of non-standard values like - [!] and you want that entry ' +

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -155,17 +155,15 @@ export function removeIncompleteTodos(
                }
            }
            if (itemFound) {
-               console.info(`found ${item} in input of todos to remove`);
                if (result.todo.complete && !todoHasIncompleteItem(result.todo)) {
                    // If the item is complete with no incomplete children, it's likely that a later note re-introduced
                    // the incomplete item. It should not be removed from this note
-                   console.warn(`However, the todo is complete with no incomplete children, so it should be kept`)
+                   console.info(`Not removing ${item} because it is complete`);
                    updatedNoteText.push(...lines.slice(i, i + result.numItems));
                } else {
-                   console.info("The todo was incomplete or had incomplete children, so removed")
+                   console.info(`Removing ${item} because it is incomplete and was added to today's note`);
                }
            } else {
-               console.debug(`This todo was not found in the input of todos to remove: ${result.todo.item}`);
                updatedNoteText.push(...lines.slice(i, i + result.numItems));
            }
            i += result.numItems - 1;

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -94,15 +94,87 @@ export function parseTextForTodos(text: string, bySection: boolean, allowedChars
             sectionTitle = parseLineForTitle(lines[i])
         }
         if (null !== result.todo && result.todo.item !== '') {
-            i += result.numItems - 1
             if (bySection && sectionTitle != null) {
                 updateElseSet(todosBySection, sectionTitle, result.todo)
             } else {
                 updateElseSet(todosBySection, untitled, result.todo)
             }
+            i += result.numItems - 1;
         }
     }
     return todosBySection
+}
+
+/**
+ * Given a Map of ToDoNodes optionally grouped by section that have been considered for addition to today's daily note,
+ * remove them from the previous parsed note text
+ *
+ * Updating the previous note with the new text is done outside of this function
+ *
+ * WARNING: The plugin does not enforce equality of children nodes between todos, meaning if a Todo had different
+ * children in a later note, the information about the previous children will be lost forever when this removes the old
+ * Todo and its children
+ *
+ * @param previousText The text of the previous note
+ * @param incompleteTodos Map of section to incomplete TodoNodes that should be removed
+ * @param bySection Whether the provided Todos and the previous notes should attempt to only match Todos in the same section
+ * @param allowedChars An array of the characters that will be recognized as valid states of a todo
+ * @param completeChars A set of the characters that signify a todo is complete
+ */
+export function removeIncompleteTodos(
+    previousText: string,
+    incompleteTodos: Map<string, TodoNode[]>,
+    bySection: boolean,
+    allowedChars: Set<string>,
+    completeChars: Set<string>
+): string {
+    const lines = previousText.split('\n');
+    const updatedNoteText: string[] = [];
+
+    let sectionTitle: string | null = null;
+    const untitled = "Untitled";
+
+    for (let i = 0; i < lines.length; i++) {
+       const result = parseForTodos(allowedChars, completeChars, lines, i, -1)
+       if (null === result.todo) {
+           sectionTitle = parseLineForTitle(lines[i])
+       }
+       if (null !== result.todo && result.todo.item !== '') {
+           // It's an Todo item, check if it's one that we should keep or remove
+           const sectionToCheck = (bySection && sectionTitle !== null) ? sectionTitle : untitled;
+           const item = result.todo.item;
+
+           const todosToCheck = incompleteTodos.get(sectionToCheck);
+           let itemFound = false;
+           if (todosToCheck) {
+               for (let j = 0; j < todosToCheck.length; j++) {
+                   if (todosToCheck[j].item === item) {
+                       itemFound = true;
+                       break;
+                   }
+               }
+           }
+           if (itemFound) {
+               console.info(`found ${item} in input of todos to remove`);
+               if (result.todo.complete && !todoHasIncompleteItem(result.todo)) {
+                   // If the item is complete with no incomplete children, it's likely that a later note re-introduced
+                   // the incomplete item. It should not be removed from this note
+                   console.warn(`However, the todo is complete with no incomplete children, so it should be kept`)
+                   updatedNoteText.push(...lines.slice(i, i + result.numItems));
+               } else {
+                   console.info("The todo was incomplete or had incomplete children, so removed")
+               }
+           } else {
+               console.debug(`This todo was not found in the input of todos to remove: ${result.todo.item}`);
+               updatedNoteText.push(...lines.slice(i, i + result.numItems));
+           }
+           i += result.numItems - 1;
+       } else {
+           // line is not a todo, keep it
+           updatedNoteText.push(lines[i]);
+       }
+    }
+    return updatedNoteText.join("\n");
 }
 
 export function parseLineForTitle(line: string): string | null {

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -1,3 +1,4 @@
+export const UntitledSection = "Untitled";
 export interface TodoNode {
     item: string
     complete: boolean
@@ -86,7 +87,6 @@ export function parseTextForTodos(text: string, bySection: boolean, allowedChars
 
     let sectionTitle: string | null = null
     const todosBySection = new Map<string, TodoNode[]>();
-    const untitled = "Untitled"
 
     for (let i = 0; i < lines.length; i++) {
         const result = parseForTodos(allowedChars, completeChars, lines, i, -1)
@@ -97,7 +97,7 @@ export function parseTextForTodos(text: string, bySection: boolean, allowedChars
             if (bySection && sectionTitle != null) {
                 updateElseSet(todosBySection, sectionTitle, result.todo)
             } else {
-                updateElseSet(todosBySection, untitled, result.todo)
+                updateElseSet(todosBySection, UntitledSection, result.todo)
             }
             i += result.numItems - 1;
         }
@@ -132,7 +132,6 @@ export function removeIncompleteTodos(
     const updatedNoteText: string[] = [];
 
     let sectionTitle: string | null = null;
-    const untitled = "Untitled";
 
     for (let i = 0; i < lines.length; i++) {
        const result = parseForTodos(allowedChars, completeChars, lines, i, -1)
@@ -141,7 +140,7 @@ export function removeIncompleteTodos(
        }
        if (null !== result.todo && result.todo.item !== '') {
            // It's an Todo item, check if it's one that we should keep or remove
-           const sectionToCheck = (bySection && sectionTitle !== null) ? sectionTitle : untitled;
+           const sectionToCheck = (bySection && sectionTitle !== null) ? sectionTitle : UntitledSection;
            const item = result.todo.item;
 
            const todosToCheck = incompleteTodos.get(sectionToCheck);

--- a/test/SampleRemovingIncompleteItemsFromPreviousNotes/newDay.input
+++ b/test/SampleRemovingIncompleteItemsFromPreviousNotes/newDay.input
@@ -1,0 +1,14 @@
+# New Daily Note
+
+With some existing text
+
+## Work
+- [x] Incomplete item that is already completed in new note
+- [x] Completed item that is also completed in new note
+- [ ] Completed item that is incomplete in new note
+- [ ] Incomplete item with incomplete child
+	- [ ] Incomplete child
+- [ ] Incomplete item with child that is complete in new note
+	- [x] Incomplete child that is already complete in new note
+
+#tags

--- a/test/SampleRemovingIncompleteItemsFromPreviousNotes/newDay.output
+++ b/test/SampleRemovingIncompleteItemsFromPreviousNotes/newDay.output
@@ -1,0 +1,17 @@
+# New Daily Note
+
+With some existing text
+
+## Work
+- [ ] Incomplete item that does not already exist in new note
+- [x] Incomplete item that is already completed in new note
+- [x] Completed item that is also completed in new note
+- [ ] Completed item that is incomplete in new note
+- [ ] Incomplete item with incomplete child
+	- [ ] Incomplete child
+- [ ] Incomplete item with child that is complete in new note
+	- [x] Incomplete child that is already complete in new note
+- [x] Completed item that is not in new note with an incomplete child
+    - [ ] Incomplete child
+
+#tags

--- a/test/SampleRemovingIncompleteItemsFromPreviousNotes/newDay.output
+++ b/test/SampleRemovingIncompleteItemsFromPreviousNotes/newDay.output
@@ -4,6 +4,8 @@ With some existing text
 
 ## Work
 - [ ] Incomplete item that does not already exist in new note
+- [x] Completed item that is not in new note with an incomplete child
+	- [ ] Incomplete child
 - [x] Incomplete item that is already completed in new note
 - [x] Completed item that is also completed in new note
 - [ ] Completed item that is incomplete in new note
@@ -11,7 +13,5 @@ With some existing text
 	- [ ] Incomplete child
 - [ ] Incomplete item with child that is complete in new note
 	- [x] Incomplete child that is already complete in new note
-- [x] Completed item that is not in new note with an incomplete child
-    - [ ] Incomplete child
 
 #tags

--- a/test/SampleRemovingIncompleteItemsFromPreviousNotes/previousDay.input
+++ b/test/SampleRemovingIncompleteItemsFromPreviousNotes/previousDay.input
@@ -1,0 +1,18 @@
+This sample contains cases where carried over todos should be deleted from the previous note
+
+## Work
+- [ ] Incomplete item that is already completed in new note
+- [x] Completed item that is also completed in new note
+- [x] Completed item that is incomplete in new note
+- [ ] Incomplete item with incomplete child
+	- [ ] Incomplete child
+- [ ] Incomplete item with child that is complete in new note
+	- [ ] Incomplete child that is already complete in new note
+- [ ] Incomplete item that does not already exist in new note
+- [x] Completed item that is not in new note
+- [x] Completed item that is not in new note with an incomplete child
+    - [ ] Incomplete child
+
+Suspendisse tempus, magna sed semper mollis, ex leo ullamcorper neque, vel faucibus sem odio quis velit
+
+#tags

--- a/test/SampleRemovingIncompleteItemsFromPreviousNotes/previousDay.output
+++ b/test/SampleRemovingIncompleteItemsFromPreviousNotes/previousDay.output
@@ -1,0 +1,10 @@
+This sample contains cases where carried over todos should be deleted from the previous note
+
+## Work
+- [x] Completed item that is also completed in new note
+- [x] Completed item that is incomplete in new note
+- [x] Completed item that is not in new note
+
+Suspendisse tempus, magna sed semper mollis, ex leo ullamcorper neque, vel faucibus sem odio quis velit
+
+#tags

--- a/test/SampleWithExistingTodos/previousDay.output
+++ b/test/SampleWithExistingTodos/previousDay.output
@@ -1,0 +1,16 @@
+This sample contains corner cases where the new note already contains some of the
+previous todos in various states
+
+## Work
+- [ ] Incomplete item that is already completed in new note
+- [x] Completed item that is also completed in new note
+- [x] Completed item that is incomplete in new note
+- [ ] Incomplete item with incomplete child
+	- [ ] Incomplete child
+- [ ] Incomplete item with child that is complete in new note
+	- [ ] Incomplete child that is already complete in new note
+- [ ] Incomplete item that does not already exist in new note
+
+Suspendisse tempus, magna sed semper mollis, ex leo ullamcorper neque, vel faucibus sem odio quis velit
+
+#tags

--- a/test/SampleWithMultipleSectionHeaders/previousDay.output
+++ b/test/SampleWithMultipleSectionHeaders/previousDay.output
@@ -1,0 +1,18 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Morbi nec pretium libero, quis volutpat odio.
+Suspendisse potenti.
+
+## Work
+- [ ] Item 1
+- [x] Item 2
+
+## Personal
+- [x] Item 3
+- [ ] Item 4
+
+## Header not present in new note
+- [ ] Item 5
+
+Suspendisse tempus, magna sed semper mollis, ex leo ullamcorper neque, vel faucibus sem odio quis velit
+
+#tags

--- a/test/SampleWithSupportedTodoStates/previousDay.output
+++ b/test/SampleWithSupportedTodoStates/previousDay.output
@@ -1,0 +1,8 @@
+This sample contains examples of todos with some of the optional states supported by some themese.
+
+## Work
+- [ ] Incomplete
+- [x] Typical complete
+- [/] Partially complete
+- [-] Canceled
+- [?] Question

--- a/test/todo.test.ts
+++ b/test/todo.test.ts
@@ -522,6 +522,7 @@ describe('golden examples', () => {
         ['SampleWithMultipleSectionHeaders', true],
         ['SampleWithExistingTodos', true],
         ['SampleWithSupportedTodoStates', true],
+        ['SampleRemovingIncompleteItemsFromPreviousNotes']
     ])('Produces expected output for %s', (sampleDir: string, bySection: boolean) => {
         // Given
         const previousNoteText = fs.readFileSync(path.join(__dirname, sampleDir, 'previousDay.input'), 'utf8');

--- a/test/todo.test.ts
+++ b/test/todo.test.ts
@@ -12,7 +12,7 @@ import {
     removeIncompleteTodos,
     todoHasIncompleteItem,
     TodoNode,
-    todosToString
+    todosToString, UntitledSection
 } from "../src/todo";
 import * as fs from "fs";
 import * as path from "path";
@@ -217,13 +217,13 @@ describe('calculateRemainingIncompleteTodos', () => {
     it('identical todo on multiple days only appears once', () => {
         // Given
         const todos: Map<string, TodoNode[]>[] = [
-            new Map<string, TodoNode[]>([["untitled", [{
+            new Map<string, TodoNode[]>([[UntitledSection, [{
                 item: "item 1",
                 state: " ",
                 complete: false,
                 children: []
             }]]]),
-            new Map<string, TodoNode[]>([["untitled", [{
+            new Map<string, TodoNode[]>([[UntitledSection, [{
                 item: "item 1",
                 state: " ",
                 complete: false,
@@ -236,7 +236,7 @@ describe('calculateRemainingIncompleteTodos', () => {
 
         // Then
         const expected = new Map<string, TodoNode[]>([
-            ["untitled", [{item: "item 1", state: " ", complete: false, children: []}]]
+            [UntitledSection, [{item: "item 1", state: " ", complete: false, children: []}]]
         ])
         expect(incompleteTodos).toMatchObject(expected)
     });
@@ -244,13 +244,13 @@ describe('calculateRemainingIncompleteTodos', () => {
     it('incomplete todo that appears on multiple days with different children is replaced by latest', () => {
         // Given
         const todos: Map<string, TodoNode[]>[] = [
-            new Map<string, TodoNode[]>([["untitled", [{
+            new Map<string, TodoNode[]>([[UntitledSection, [{
                 item: "item 1",
                 state: " ",
                 complete: false,
                 children: []
             }]]]),
-            new Map<string, TodoNode[]>([["untitled", [{
+            new Map<string, TodoNode[]>([[UntitledSection, [{
                 item: "item 1",
                 state: " ",
                 complete: false,
@@ -270,7 +270,7 @@ describe('calculateRemainingIncompleteTodos', () => {
 
         // Then
         const expected = new Map<string, TodoNode[]>([
-            ["untitled", [{
+            [UntitledSection, [{
                 item: "item 1", state: " ", complete: false, children: [
                     {
                         item: "new nested item",
@@ -287,13 +287,13 @@ describe('calculateRemainingIncompleteTodos', () => {
     it('incomplete Todo complete on later day is removed', () => {
         // Given
         const todos: Map<string, TodoNode[]>[] = [
-            new Map<string, TodoNode[]>([["untitled", [{
+            new Map<string, TodoNode[]>([[UntitledSection, [{
                 item: "item 1",
                 state: " ",
                 complete: false,
                 children: []
             }]]]),
-            new Map<string, TodoNode[]>([["untitled", [{
+            new Map<string, TodoNode[]>([[UntitledSection, [{
                 item: "item 1",
                 state: "x",
                 complete: true,
@@ -313,26 +313,26 @@ describe('calculateRemainingIncompleteTodos', () => {
         const incompleteTodos = calculateRemainingIncompleteTodos(todos);
 
         // Then
-        expect(incompleteTodos).toMatchObject(new Map<string, TodoNode[]>([["untitled", []]]))
+        expect(incompleteTodos).toMatchObject(new Map<string, TodoNode[]>([[UntitledSection, []]]))
 
     });
 
     it('todo that has incomplete, complete, incomplete days is re-added', () => {
         // Given
         const todos: Map<string, TodoNode[]>[] = [
-            new Map<string, TodoNode[]>([["untitled", [{
+            new Map<string, TodoNode[]>([[UntitledSection, [{
                 item: "item 1",
                 state: " ",
                 complete: false,
                 children: []
             }]]]),
-            new Map<string, TodoNode[]>([["untitled", [{
+            new Map<string, TodoNode[]>([[UntitledSection, [{
                 item: "item 1",
                 state: "x",
                 complete: true,
                 children: []
             }]]]),
-            new Map<string, TodoNode[]>([["untitled", [{
+            new Map<string, TodoNode[]>([[UntitledSection, [{
                 item: "item 1",
                 state: " ",
                 complete: false,
@@ -345,7 +345,7 @@ describe('calculateRemainingIncompleteTodos', () => {
 
         // Then
         const expected = new Map<string, TodoNode[]>([
-            ["untitled", [{item: "item 1", state: " ", complete: false, children: []}]]
+            [UntitledSection, [{item: "item 1", state: " ", complete: false, children: []}]]
         ])
         expect(incompleteTodos).toMatchObject(expected);
     });
@@ -415,7 +415,7 @@ describe('insertTodos', () => {
     it('new text contains provided todos', () => {
         // Given
         const todos: Map<string, TodoNode[]> = new Map<string, TodoNode[]>([
-            ["untitled",
+            [UntitledSection,
                 [
                     {
                         item: "item 1",
@@ -512,6 +512,209 @@ more text
 
 ## personal
 - [ ] personal item
+
+more text
+`);
+    });
+});
+
+describe('removeIncompleteTodos', () => {
+    it('Complete items are not removed even when specified', () => {
+        // Given
+        const initialNoteText = `
+## work
+- [x] foo
+
+## personal
+
+more text
+`;
+        const incompleteTodos: Map<string, TodoNode[]> = new Map([
+            ['## work', [{item: "foo", state: "x", children: [], complete: true}]],
+        ]);
+        const bySection = true;
+
+
+        // When
+        const newNoteText = removeIncompleteTodos(initialNoteText, incompleteTodos, bySection, allowedChars, completeChars);
+
+        // Then
+        expect(newNoteText).toBe(`
+## work
+- [x] foo
+
+## personal
+
+more text
+`);
+    });
+
+    it('Only specified incomplete items are removed', () => {
+        // Given
+        const initialNoteText = `
+## work
+- [ ] foo
+- [ ] bar
+- [ ] baz
+  - [ ] abc
+
+## personal
+
+more text
+`;
+        const incompleteTodos: Map<string, TodoNode[]> = new Map([
+            ['## work', [
+                {item: "foo", state: " ", children: [], complete: false},
+                {item: "bar", state: " ", children: [], complete: false}
+            ]],
+        ]);
+        const bySection = true;
+
+
+        // When
+        const newNoteText = removeIncompleteTodos(initialNoteText, incompleteTodos, bySection, allowedChars, completeChars);
+
+        // Then
+        expect(newNoteText).toBe(`
+## work
+- [ ] baz
+  - [ ] abc
+
+## personal
+
+more text
+`);
+    });
+
+    it('Incomplete items with children have children removed', () => {
+        // Given
+        const initialNoteText = `
+## work
+- [ ] foo
+  - [x] bar
+    - [x] baz
+- [ ] abc
+  - [?] abc
+- [x] def
+
+## personal
+
+more text
+`;
+        const incompleteTodos: Map<string, TodoNode[]> = new Map([
+            ['## work', [
+                {item: "foo", state: " ", children: [], complete: false}, // It doesn't matter that the children are different
+                {item: "abc", state: " ", children: [{item: "abc", state: "!", children: [], complete: false}], complete: false},
+            ]],
+        ]);
+        const bySection = true;
+
+
+        // When
+        const newNoteText = removeIncompleteTodos(initialNoteText, incompleteTodos, bySection, allowedChars, completeChars);
+
+        // Then
+        expect(newNoteText).toBe(`
+## work
+- [x] def
+
+## personal
+
+more text
+`);
+    });
+
+    it('Nothing is removed when specified items are not found in text', () => {
+        // Given
+        const initialNoteText = `
+## work
+- [ ] foo
+- [x] bar
+
+## personal
+
+more text
+`;
+        const incompleteTodos: Map<string, TodoNode[]> = new Map([
+            ['## work', [{item: "baz", state: " ", children: [], complete: true}]],
+        ]);
+        const bySection = true;
+
+
+        // When
+        const newNoteText = removeIncompleteTodos(initialNoteText, incompleteTodos, bySection, allowedChars, completeChars);
+
+        // Then
+        expect(newNoteText).toBe(initialNoteText);
+    });
+
+    it('When grouping by section, matching items are not removed from other sections', () => {
+        // Given
+        const initialNoteText = `
+No section
+- [ ] foo
+     
+## work
+- [ ] foo
+
+## personal
+- [ ] foo
+
+more text
+`;
+        const incompleteTodos: Map<string, TodoNode[]> = new Map([
+            ['## work', [{item: "foo", state: " ", children: [], complete: false}]],
+        ]);
+        const bySection = true;
+
+
+        // When
+        const newNoteText = removeIncompleteTodos(initialNoteText, incompleteTodos, bySection, allowedChars, completeChars);
+
+        // Then
+        expect(newNoteText).toBe(`
+No section
+- [ ] foo
+     
+## work
+
+## personal
+- [ ] foo
+
+more text
+`);
+    });
+
+    it('When not grouping by section, matching items are not removed from any section', () => {
+        // Given
+        const initialNoteText = `
+No section
+- [ ] foo
+     
+## work
+- [ ] foo
+
+## personal
+- [ ] foo
+
+more text
+`;
+        const incompleteTodos: Map<string, TodoNode[]> = new Map([
+            [UntitledSection, [{item: "foo", state: " ", children: [], complete: false}]],
+        ]);
+        const bySection = false;
+
+
+        // When
+        const newNoteText = removeIncompleteTodos(initialNoteText, incompleteTodos, bySection, allowedChars, completeChars);
+
+        // Then
+        expect(newNoteText).toBe(`
+No section
+     
+## work
+
+## personal
 
 more text
 `);


### PR DESCRIPTION
Closes #5 

New option will remove incomplete Todos that were added to today's note from the previous notes that were parsed.

Limitations:
- The incomplete item and its children will only be removed from the notes that are parsed, not all previous notes.
- Children are not checked for equality, so if an item's children have changed in intermediate notes, that information will be lost. Only the most recent version of the item is added to today's note, and all versions of the incomplete item will be removed from the previous parsed notes
- Only items that were actually added to today's note are removed. i.e. Items that are already present in today's note are not removed. Out of an abundance of caution around losing data from previous notes, I limited the removal to only copied items. This could be updated, but this simple plugin is not intended to be a full featured manager of todo tasks.
- Items are only removed _after_ today's note has been updated successfully, so previous notes end up parsed twice. This was also to reduce the chances of lost data if something were to fail updating today's note.